### PR TITLE
מנוע אינטגרציה: אישור בקשה → סשן Claude אוטומטי (בטור, בלי התנגשות)

### DIFF
--- a/request-orchestrator/.env.example
+++ b/request-orchestrator/.env.example
@@ -1,0 +1,21 @@
+# Which adapter creates the Claude session: ccrApi (cloud) or localCli (local machine)
+ADAPTER=ccrApi
+
+# HTTP port the orchestrator listens on (the /requests app POSTs approvals here)
+PORT=4500
+
+# How many requests may run at once. 1 = strictly serialized, no overlap (recommended).
+MAX_CONCURRENCY=1
+
+# Poll interval (ms) for checking whether a running session finished
+POLL_INTERVAL_MS=15000
+
+# --- Claude Code Remote API (adapter=ccrApi) ---
+# Base URL + token for creating sessions programmatically, and the target environment id.
+CCR_API_URL=
+CCR_API_TOKEN=
+CCR_ENV_ID=env_01Ee5tLoXsNzojCWpfvhmBxc
+
+# --- Local CLI (adapter=localCli) ---
+# Path to the Claude CLI on the office machine (defaults to "claude" on PATH)
+CLAUDE_CLI=claude

--- a/request-orchestrator/.env.example
+++ b/request-orchestrator/.env.example
@@ -1,4 +1,7 @@
-# Which adapter creates the Claude session: ccrApi (cloud) or localCli (local machine)
+# Which adapter creates the Claude session:
+#   ccrApi   - Claude Code Remote (cloud)
+#   localCli - headless `claude` on the office machine
+#   mock     - simulated session, for safe local testing + demoing the dashboard
 ADAPTER=ccrApi
 
 # HTTP port the orchestrator listens on (the /requests app POSTs approvals here)
@@ -9,6 +12,9 @@ MAX_CONCURRENCY=1
 
 # Poll interval (ms) for checking whether a running session finished
 POLL_INTERVAL_MS=15000
+
+# A running session longer than this (ms) is force-failed so the queue never wedges. Default 1h.
+SESSION_TIMEOUT_MS=3600000
 
 # --- Claude Code Remote API (adapter=ccrApi) ---
 # Base URL + token for creating sessions programmatically, and the target environment id.

--- a/request-orchestrator/.gitignore
+++ b/request-orchestrator/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 data/approved-queue.json
 data/orchestrator.lock
 data/*.tmp
+data/test-*.json

--- a/request-orchestrator/.gitignore
+++ b/request-orchestrator/.gitignore
@@ -1,0 +1,5 @@
+.env
+node_modules/
+data/approved-queue.json
+data/orchestrator.lock
+data/*.tmp

--- a/request-orchestrator/HANDOFF.md
+++ b/request-orchestrator/HANDOFF.md
@@ -1,0 +1,68 @@
+# מסמך העברה — מערכת הבקשות → סשן Claude אוטומטי
+
+עודכן: 11.07.2026 · נכתב בסשן ענן (Claude Code on the web) בזמן שאייל ישן.
+
+## המטרה (מהבקשה של אייל)
+
+> "הציפייה שלי שאוכל לאשר בקשות ולגבי כל בקשה יהיה אוטומט סשן בקלוד … בצורה חכמה ונכונה,
+> ושלא יקרה מצב שסשן אחד מתלבש על אחר. שתהיה איזושהי אינטגרציה."
+
+## מה נבנה (מוכן ובדוק)
+
+| רכיב | קובץ | מצב |
+|------|------|-----|
+| תור בקשות מאושרות (FIFO, נשמר לדיסק, crash-safe) | `src/queue.js` | ✅ + טסטים |
+| סריאליזציה — בקשה אחת בכל רגע (`MAX_CONCURRENCY=1`) | `src/orchestrator.js` | ✅ + טסטים |
+| נעילת מופע-יחיד | `src/lock.js` | ✅ |
+| timeout לסשן תקוע (ברירת מחדל שעה) | `src/orchestrator.js` | ✅ |
+| API: `POST /approve`, `GET /status` | `src/server.js` | ✅ smoke |
+| לוח בקשות/סשנים בעברית (מתעדכן לבד) | `public/dashboard.html` | ✅ הדגמה נשלחה |
+| Adapter ענן (Claude Code Remote) | `src/adapters/ccrApi.js` | ⚠️ TODO אחד (endpoint) |
+| Adapter מקומי (`claude -p`) | `src/adapters/localCli.js` | ✅ |
+| Adapter דמה (בדיקות/הדגמה) | `src/adapters/mock.js` | ✅ + טסטים |
+
+בדיקות: `node --test` → 5/5 עוברים. הדגמה חיה עם `ADAPTER=mock` רצה מקצה-לקצה
+(אישור → תור → סשן → done) והלוח הציג את המצב.
+
+## הזרימה
+
+```
+/requests (פורט 3000)  →(אישור: POST /approve)→  תור  →  orchestrator (concurrency=1)  →  סשן Claude  →  /status  →  לוח בעברית
+```
+
+## מה צריך ממך כדי לעלות לאוויר (3 דברים)
+
+1. **פרטי Claude Code Remote API** — כתובת + טוקן + `env id`, ל-`.env`
+   (`CCR_API_URL`, `CCR_API_TOKEN`, `CCR_ENV_ID`). יש `TODO` אחד ב-`ccrApi.js` על ה-endpoint המדויק
+   של יצירת סשן — צריך לאמת מול התיעוד שלך. **עד אז אפשר להריץ כבר היום עם `ADAPTER=localCli`**
+   (הרצה מקומית על EYAL) או `ADAPTER=mock` (הדגמה).
+2. **hook בצד `/requests`** — שורת `fetch("http://localhost:4500/approve", …)` בכפתור "אשר"
+   (קוד מלא ב-`README.md`).
+3. **ייצוא הבקשות הקיימות** (JSON/CSV) — כדי שאעבור על הפתוחות, תגובות לברינה/לך, וניסוחים לא-ברורים.
+   הסשן בענן לא מגיע ל-localhost:3000.
+
+## איך להריץ עכשיו (בלי שום פרט חסר)
+
+```bash
+cd request-orchestrator
+cp .env.example .env         # ADAPTER=mock כדי לראות את הלוח עובד
+node src/index.js            # פותח http://localhost:4500 (לוח) + API
+# בטרמינל אחר:
+curl -X POST http://localhost:4500/approve -H "Content-Type: application/json" \
+  -d '{"id":"T1","title":"בדיקה","requester":"אייל"}'
+# פתח בדפדפן http://localhost:4500 — הבקשה תופיע ותעבור pending→running→done
+```
+
+## החלטות עיצוב
+
+- **למה תור-קובץ ולא ישר API?** כדי שאישור לא ילך לאיבוד אם ה-orchestrator לא רץ רגע,
+  וכדי שקריסה באמצע לא תריץ בקשה פעמיים (כל פריט מקבל `claimedAt`).
+- **למה concurrency=1?** זו הדרישה המפורשת שלך — "שלא יתלבש סשן על סשן". ניתן להגדיל ב-.env
+  אם תרצה מקביליות מבוקרת בעתיד.
+- **למה adapters?** כדי שאותה לוגיקה תרוץ גם בענן (CCR) וגם מקומית (CLI) בלי לשכתב —
+  והבחירה היא שורה אחת ב-.env.
+
+## פתוח לשיקולך (לא בוצע בכוונה)
+
+- לא יצרתי טריגר/סשן חי ב-Claude Code Remote — לא רציתי להריץ אוטומציה חיה בלי אישורך
+  (כלל: לא לגעת במערכת חיה בלי תיאום). ברגע שתיתן אור — אפעיל בזהירות.

--- a/request-orchestrator/README.md
+++ b/request-orchestrator/README.md
@@ -1,0 +1,79 @@
+# Request Orchestrator — אישור בקשה → סשן Claude אוטומטי
+
+מנוע אינטגרציה שמחבר את **מערכת הבקשות** (מודול המשימות/בקשות ב-OfficeChatServer, פורט 3000,
+`/requests`) ל-**Claude Code Remote**: כל בקשה שאייל מאשר יוצרת אוטומטית סשן Claude שמבצע אותה —
+**בטור, בלי שסשן אחד יתלבש על אחר**.
+
+## הזרימה
+
+```
+מערכת הבקשות (/requests, פורט 3000)
+   │  אייל לוחץ "אשר"
+   ▼
+POST /approve  →  approved-queue.json  (תור FIFO, נשמר לדיסק)
+   │
+   ▼
+Orchestrator loop  (MAX_CONCURRENCY = 1, נעילה)
+   │  שולף את הבקשה הבאה → בונה prompt → adapter.createSession()
+   ▼
+Claude Code Remote — סשן ענן שמריץ את הבקשה
+   │  polling לסטטוס עד done / failed
+   ▼
+results.json  (סטטוס + סיכום + קישור לסשן)  →  מערכת הבקשות מציגה סטטוס
+```
+
+## למה זה לא מתנגש
+
+- ה-orchestrator מעבד **בקשה אחת בכל רגע** (`MAX_CONCURRENCY=1`). הבא בתור מתחיל רק אחרי
+  שהקודם הגיע ל-`done`/`failed`.
+- קובץ נעילה (`data/orchestrator.lock`) מונע שתי מופעים במקביל של ה-orchestrator עצמו.
+- כל פריט בתור מקבל `claimedAt` — פריט "תפוס" לא נלקח שוב, כך שגם קריסה באמצע לא מריצה כפול.
+
+## התקנה והרצה
+
+```bash
+cd request-orchestrator
+npm install            # אין תלויות חיצוניות — רק Node 18+
+cp .env.example .env   # מלא CCR_API_URL / CCR_API_TOKEN / CCR_ENV_ID
+node src/index.js      # מריץ HTTP server (POST /approve, GET /status) + לולאת עיבוד
+```
+
+## החיבור למערכת הבקשות (הקוד שצריך להוסיף שם)
+
+בכפתור "אשר" של `/requests`, אחרי שהבקשה מסומנת מאושרת, שלח אותה ל-orchestrator:
+
+```js
+await fetch("http://localhost:4500/approve", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    id: request.id,               // מזהה ייחודי מהמערכת
+    title: request.title,         // כותרת הבקשה
+    body: request.body,           // הטקסט המלא / מה לבצע
+    system: request.system,       // שם המערכת (מהמרשם) — אופציונלי
+    requester: request.requester, // מי ביקש (אייל / ברינה...) — אופציונלי
+    acceptance: request.acceptance// קריטריון "בוצע" — אופציונלי אך מומלץ
+  })
+});
+```
+
+לתצוגת סטטוס: `GET http://localhost:4500/status` מחזיר את מצב כל הבקשות (ממתין / רץ / הושלם / נכשל).
+
+## Adapters — איך נוצר הסשן
+
+`src/adapters/` מפריד בין הלוגיקה לבין *איך* מריצים סשן Claude. שני מימושים:
+
+| adapter | מתי | מה צריך |
+|---|---|---|
+| `ccrApi` (ברירת מחדל) | סשן בענן Claude Code Remote | `CCR_API_URL`, `CCR_API_TOKEN`, `CCR_ENV_ID` ב-.env |
+| `localCli` | הרצה מקומית על מכונת המשרד דרך `claude -p` | ה-CLI של Claude מותקן על המכונה |
+
+בחירת adapter דרך `ADAPTER=ccrApi` / `ADAPTER=localCli` ב-.env.
+
+## מה עוד צריך ממך (אייל) כדי לסגור את המעגל
+
+1. **פרטי ה-API של Claude Code Remote** — כתובת + טוקן ליצירת סשן פרוגרמטית (למילוי ב-.env).
+   *כרגע `ccrApi.js` מכיל את מבנה הקריאה עם TODO אחד במקום ה-endpoint המדויק.*
+2. **ה-hook בצד `/requests`** — הוספת ה-`fetch` לכפתור "אשר" (הקוד למעלה).
+3. **ייצוא הבקשות הקיימות** (JSON/CSV) — כדי שאעבור על הפתוחות, תגובות לברינה/לך, וניסוחים לא-ברורים.
+   הסשן הזה בענן לא מגיע ל-localhost:3000 שלך.

--- a/request-orchestrator/data/sample-approved-queue.json
+++ b/request-orchestrator/data/sample-approved-queue.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "REQ-001",
+    "title": "דוגמה — הוספת לוגו המשרד לדוח דיבידנד",
+    "body": "להוסיף את לוגו המשרד לראש דוח הדיבידנד במחשבון הדיבידנד.",
+    "system": "dividend-calc",
+    "requester": "אייל",
+    "acceptance": "הלוגו מופיע בראש הדוח המודפס ובתצוגה.",
+    "status": "pending",
+    "enqueuedAt": "2026-07-11T00:00:00.000Z",
+    "claimedAt": null,
+    "finishedAt": null,
+    "sessionId": null,
+    "sessionUrl": null,
+    "result": null,
+    "error": null
+  }
+]

--- a/request-orchestrator/package.json
+++ b/request-orchestrator/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "request-orchestrator",
+  "version": "0.1.0",
+  "description": "Approve a request in the requests system -> auto Claude Code Remote session, serialized (no overlap).",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/request-orchestrator/public/dashboard.html
+++ b/request-orchestrator/public/dashboard.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>לוח בקשות וסשנים — רייטר & ציון</title>
+<style>
+  :root {
+    --bg: #f4f6f9; --card: #ffffff; --ink: #1a1f2b; --muted: #6b7280;
+    --line: #e3e8ef; --navy: #1F3A5F; --blue: #2E5A88;
+    --pending: #6b7280; --running: #b8860b; --done: #2f7d32; --failed: #b03030;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg:#0f141b; --card:#161d27; --ink:#e6eaf0; --muted:#9aa4b2; --line:#232b36; --navy:#8fb3e0; --blue:#7aa0c8; }
+  }
+  * { box-sizing: border-box; }
+  body { margin:0; font-family: Arial, "Segoe UI", sans-serif; background:var(--bg); color:var(--ink); }
+  header { background:var(--navy); color:#fff; padding:14px 20px; display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:8px; }
+  header h1 { font-size:18px; margin:0; }
+  header .sub { font-size:12px; opacity:.85; }
+  .wrap { max-width:1100px; margin:0 auto; padding:18px; }
+  .tiles { display:grid; grid-template-columns:repeat(4,1fr); gap:12px; margin-bottom:18px; }
+  @media (max-width:640px){ .tiles{ grid-template-columns:repeat(2,1fr);} }
+  .tile { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:14px; text-align:center; }
+  .tile .n { font-size:26px; font-weight:700; }
+  .tile .l { font-size:12px; color:var(--muted); margin-top:2px; }
+  .tile.pending .n{color:var(--pending)} .tile.running .n{color:var(--running)}
+  .tile.done .n{color:var(--done)} .tile.failed .n{color:var(--failed)}
+  h2 { font-size:15px; color:var(--blue); margin:18px 0 8px; }
+  .card { background:var(--card); border:1px solid var(--line); border-radius:12px; overflow:hidden; }
+  .scroll { overflow-x:auto; }
+  table { width:100%; border-collapse:collapse; font-size:13px; min-width:640px; }
+  th,td { padding:10px 12px; text-align:right; border-bottom:1px solid var(--line); vertical-align:top; }
+  th { background:rgba(46,90,136,.08); color:var(--blue); font-weight:700; position:sticky; top:0; }
+  tr:last-child td { border-bottom:none; }
+  .pill { display:inline-block; padding:2px 10px; border-radius:999px; font-size:11px; font-weight:700; color:#fff; white-space:nowrap; }
+  .pill.pending{background:var(--pending)} .pill.running{background:var(--running)}
+  .pill.done{background:var(--done)} .pill.failed{background:var(--failed)}
+  a.cont { color:var(--blue); font-weight:700; text-decoration:none; }
+  a.cont:hover { text-decoration:underline; }
+  .empty { padding:26px; text-align:center; color:var(--muted); }
+  .foot { color:var(--muted); font-size:12px; margin-top:14px; text-align:center; }
+  .dot { display:inline-block; width:8px; height:8px; border-radius:50%; background:var(--done); margin-inline-start:6px; vertical-align:middle; }
+</style>
+</head>
+<body>
+<header>
+  <div>
+    <h1>לוח בקשות וסשנים פתוחים</h1>
+    <div class="sub">רייטר & ציון — חשבונאות אקטיבית · מתעדכן אוטומטית</div>
+  </div>
+  <div class="sub"><span class="dot" id="live"></span><span id="updated">טוען…</span></div>
+</header>
+<div class="wrap">
+  <div class="tiles">
+    <div class="tile pending"><div class="n" id="c-pending">0</div><div class="l">ממתין</div></div>
+    <div class="tile running"><div class="n" id="c-running">0</div><div class="l">רץ עכשיו</div></div>
+    <div class="tile done"><div class="n" id="c-done">0</div><div class="l">הושלם</div></div>
+    <div class="tile failed"><div class="n" id="c-failed">0</div><div class="l">נכשל</div></div>
+  </div>
+
+  <h2>בקשות בתור (לפי סדר עיבוד)</h2>
+  <div class="card scroll">
+    <table>
+      <thead><tr>
+        <th>#</th><th>כותרת</th><th>מערכת</th><th>מבקש</th><th>סטטוס</th><th>סשן</th>
+      </tr></thead>
+      <tbody id="rows"><tr><td colspan="6" class="empty">טוען…</td></tr></tbody>
+    </table>
+  </div>
+
+  <div class="foot">
+    concurrency = 1 — בקשה אחת רצה בכל רגע, אף סשן לא מתלבש על אחר.
+  </div>
+</div>
+
+<script>
+  const STATUS_LABEL = { pending:"ממתין", running:"רץ", done:"הושלם", failed:"נכשל" };
+  function esc(s){ return String(s ?? "").replace(/[&<>"]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c])); }
+
+  async function refresh(){
+    try {
+      const r = await fetch("/status", { cache:"no-store" });
+      const data = await r.json();
+      const s = data.summary || {pending:0,running:0,done:0,failed:0};
+      for (const k of ["pending","running","done","failed"]) document.getElementById("c-"+k).textContent = s[k] || 0;
+
+      const items = (data.requests || []).slice().sort((a,b) => {
+        const order = { running:0, pending:1, failed:2, done:3 };
+        return (order[a.status]-order[b.status]) || String(a.enqueuedAt).localeCompare(String(b.enqueuedAt));
+      });
+      const tb = document.getElementById("rows");
+      if (!items.length){ tb.innerHTML = '<tr><td colspan="6" class="empty">אין בקשות עדיין — אישור בקשה במערכת יופיע כאן.</td></tr>'; }
+      else {
+        tb.innerHTML = items.map(it => {
+          const st = it.status || "pending";
+          const link = it.sessionUrl ? '<a class="cont" href="'+esc(it.sessionUrl)+'" target="_blank">המשך ↗</a>'
+                     : (it.error ? '<span title="'+esc(it.error)+'">—</span>' : "—");
+          return "<tr>"
+            + "<td>"+esc(it.id)+"</td>"
+            + "<td>"+esc(it.title)+"</td>"
+            + "<td>"+esc(it.system||"—")+"</td>"
+            + "<td>"+esc(it.requester||"—")+"</td>"
+            + '<td><span class="pill '+st+'">'+(STATUS_LABEL[st]||st)+"</span></td>"
+            + "<td>"+link+"</td>"
+            + "</tr>";
+        }).join("");
+      }
+      document.getElementById("updated").textContent = "עודכן " + new Date().toLocaleTimeString("he-IL");
+      document.getElementById("live").style.background = "var(--done)";
+    } catch (e){
+      document.getElementById("updated").textContent = "אין חיבור לשרת";
+      document.getElementById("live").style.background = "var(--failed)";
+    }
+  }
+  refresh();
+  setInterval(refresh, 5000);
+</script>
+</body>
+</html>

--- a/request-orchestrator/src/adapters/ccrApi.js
+++ b/request-orchestrator/src/adapters/ccrApi.js
@@ -1,0 +1,52 @@
+// Adapter: create + poll a Claude Code Remote (cloud) session over its HTTP API.
+//
+// NOTE: the exact Claude Code Remote REST endpoints/shape must be filled in by Eyal
+// (see the single TODO below). Everything around it — auth header, env id, polling,
+// status mapping — is wired. Config comes from .env (CCR_API_URL/TOKEN/ENV_ID).
+import { config } from "../config.js";
+
+function assertConfigured() {
+  const { apiUrl, apiToken, envId } = config.ccr;
+  if (!apiUrl || !apiToken || !envId) {
+    throw new Error(
+      "ccrApi adapter not configured — set CCR_API_URL, CCR_API_TOKEN, CCR_ENV_ID in .env"
+    );
+  }
+}
+
+async function api(path, options = {}) {
+  const res = await fetch(config.ccr.apiUrl.replace(/\/$/, "") + path, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${config.ccr.apiToken}`,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  if (!res.ok) throw new Error(`CCR API ${path} -> ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+export async function createSession(prompt, meta) {
+  assertConfigured();
+  // TODO(eyal): confirm the create-session endpoint + payload for your CCR API.
+  const data = await api("/v1/sessions", {
+    method: "POST",
+    body: JSON.stringify({
+      environment_id: config.ccr.envId,
+      prompt,
+      name: meta?.title?.slice(0, 80) || "request",
+    }),
+  });
+  return { sessionId: data.id, sessionUrl: data.url || null };
+}
+
+export async function getStatus(sessionId) {
+  assertConfigured();
+  const data = await api(`/v1/sessions/${sessionId}`);
+  // Map the provider's state to our three states.
+  const s = (data.state || data.status || "").toLowerCase();
+  if (["completed", "done", "succeeded", "idle", "finished"].includes(s)) return "done";
+  if (["failed", "error", "cancelled", "canceled"].includes(s)) return "failed";
+  return "running";
+}

--- a/request-orchestrator/src/adapters/localCli.js
+++ b/request-orchestrator/src/adapters/localCli.js
@@ -1,0 +1,29 @@
+// Adapter: run the request as a local headless Claude CLI session on the office
+// machine. Fully self-contained (no cloud API needed). The orchestrator controls
+// concurrency, so serialization is guaranteed regardless of adapter.
+import { spawn } from "node:child_process";
+import { config } from "../config.js";
+
+const sessions = new Map(); // sessionId -> { state, output }
+
+export async function createSession(prompt, meta) {
+  const sessionId = `local-${meta?.id ?? Date.now()}`;
+  const child = spawn(config.claudeCli, ["-p", prompt], {
+    shell: process.platform === "win32",
+  });
+  const entry = { state: "running", output: "" };
+  sessions.set(sessionId, entry);
+
+  child.stdout.on("data", (d) => (entry.output += d.toString()));
+  child.stderr.on("data", (d) => (entry.output += d.toString()));
+  child.on("close", (code) => {
+    entry.state = code === 0 ? "done" : "failed";
+  });
+  child.on("error", () => (entry.state = "failed"));
+
+  return { sessionId, sessionUrl: null };
+}
+
+export async function getStatus(sessionId) {
+  return sessions.get(sessionId)?.state || "failed";
+}

--- a/request-orchestrator/src/adapters/mock.js
+++ b/request-orchestrator/src/adapters/mock.js
@@ -1,0 +1,21 @@
+// Adapter: simulate a Claude session that finishes after a short delay. Lets you
+// exercise the full approve -> queue -> run -> done pipeline (and the dashboard)
+// with no CCR API and no Claude CLI. Select with ADAPTER=mock.
+const sessions = new Map(); // sessionId -> finishAt (ms epoch-ish via counter)
+
+let clock = 0; // monotonic counter; we avoid Date.now() so tests stay deterministic
+const DEFAULT_STEPS = 2; // getStatus calls before the session reports "done"
+
+export async function createSession(_prompt, meta) {
+  const sessionId = `mock-${meta?.id ?? ++clock}`;
+  sessions.set(sessionId, DEFAULT_STEPS);
+  return { sessionId, sessionUrl: `mock://session/${sessionId}` };
+}
+
+export async function getStatus(sessionId) {
+  const left = sessions.get(sessionId);
+  if (left === undefined) return "failed";
+  if (left <= 0) return "done";
+  sessions.set(sessionId, left - 1);
+  return "running";
+}

--- a/request-orchestrator/src/config.js
+++ b/request-orchestrator/src/config.js
@@ -1,7 +1,7 @@
 // Minimal .env loader (no external deps) + typed config accessors.
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, isAbsolute } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
 export const ROOT = join(here, "..");
@@ -27,10 +27,16 @@ export const config = {
   port: Number(process.env.PORT || 4500),
   maxConcurrency: Math.max(1, Number(process.env.MAX_CONCURRENCY || 1)),
   pollIntervalMs: Number(process.env.POLL_INTERVAL_MS || 15000),
+  // A session running longer than this is force-failed so the queue never wedges.
+  sessionTimeoutMs: Number(process.env.SESSION_TIMEOUT_MS || 60 * 60 * 1000),
   ccr: {
     apiUrl: process.env.CCR_API_URL || "",
     apiToken: process.env.CCR_API_TOKEN || "",
     envId: process.env.CCR_ENV_ID || "",
   },
   claudeCli: process.env.CLAUDE_CLI || "claude",
+  // Where the persisted queue lives. Overridable (mainly so tests can isolate).
+  queueFile: process.env.QUEUE_FILE
+    ? (isAbsolute(process.env.QUEUE_FILE) ? process.env.QUEUE_FILE : join(ROOT, process.env.QUEUE_FILE))
+    : join(DATA_DIR, "approved-queue.json"),
 };

--- a/request-orchestrator/src/config.js
+++ b/request-orchestrator/src/config.js
@@ -1,0 +1,36 @@
+// Minimal .env loader (no external deps) + typed config accessors.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const ROOT = join(here, "..");
+export const DATA_DIR = join(ROOT, "data");
+
+function loadDotEnv() {
+  try {
+    const raw = readFileSync(join(ROOT, ".env"), "utf8");
+    for (const line of raw.split(/\r?\n/)) {
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+      if (m && process.env[m[1]] === undefined) {
+        process.env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+      }
+    }
+  } catch {
+    // no .env file — rely on real environment variables
+  }
+}
+loadDotEnv();
+
+export const config = {
+  adapter: process.env.ADAPTER || "ccrApi",
+  port: Number(process.env.PORT || 4500),
+  maxConcurrency: Math.max(1, Number(process.env.MAX_CONCURRENCY || 1)),
+  pollIntervalMs: Number(process.env.POLL_INTERVAL_MS || 15000),
+  ccr: {
+    apiUrl: process.env.CCR_API_URL || "",
+    apiToken: process.env.CCR_API_TOKEN || "",
+    envId: process.env.CCR_ENV_ID || "",
+  },
+  claudeCli: process.env.CLAUDE_CLI || "claude",
+};

--- a/request-orchestrator/src/index.js
+++ b/request-orchestrator/src/index.js
@@ -1,0 +1,24 @@
+// Entry point: acquire the single-instance lock, start the HTTP API, run the loop.
+import { config } from "./config.js";
+import { acquire, release } from "./lock.js";
+import { startServer } from "./server.js";
+import { start } from "./orchestrator.js";
+
+if (!acquire()) {
+  console.error("[index] another orchestrator instance is already running — exiting.");
+  process.exit(1);
+}
+
+const server = startServer();
+const stop = start();
+console.log(`[index] request-orchestrator up (maxConcurrency=${config.maxConcurrency})`);
+
+function shutdown() {
+  console.log("[index] shutting down...");
+  stop();
+  server.close();
+  release();
+  process.exit(0);
+}
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/request-orchestrator/src/lock.js
+++ b/request-orchestrator/src/lock.js
@@ -1,0 +1,43 @@
+// Single-instance lock so two orchestrator processes never run the queue at once.
+import { openSync, closeSync, unlinkSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { DATA_DIR } from "./config.js";
+
+const LOCK_FILE = join(DATA_DIR, "orchestrator.lock");
+
+export function acquire() {
+  try {
+    // "wx" fails if the file already exists — atomic lock creation.
+    const fd = openSync(LOCK_FILE, "wx");
+    writeFileSync(fd, String(process.pid));
+    closeSync(fd);
+    return true;
+  } catch {
+    // Stale lock? If the recorded PID is gone, reclaim it.
+    if (existsSync(LOCK_FILE)) {
+      const pid = Number(readFileSync(LOCK_FILE, "utf8"));
+      if (pid && !isAlive(pid)) {
+        unlinkSync(LOCK_FILE);
+        return acquire();
+      }
+    }
+    return false;
+  }
+}
+
+export function release() {
+  try {
+    unlinkSync(LOCK_FILE);
+  } catch {
+    /* already gone */
+  }
+}
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/request-orchestrator/src/orchestrator.js
+++ b/request-orchestrator/src/orchestrator.js
@@ -5,8 +5,10 @@ import { config } from "./config.js";
 import { claimNext, markSession, markDone, markFailed } from "./queue.js";
 import { buildPrompt } from "./prompt.js";
 
+const ADAPTERS = new Set(["ccrApi", "localCli", "mock"]);
+
 async function loadAdapter() {
-  const name = config.adapter === "localCli" ? "localCli" : "ccrApi";
+  const name = ADAPTERS.has(config.adapter) ? config.adapter : "ccrApi";
   return import(`./adapters/${name}.js`);
 }
 
@@ -26,9 +28,14 @@ export async function tick() {
     markSession(req.id, { sessionId, sessionUrl });
     console.log(`[orchestrator] started ${req.id} -> session ${sessionId}`);
 
-    // Poll until the session reaches a terminal state.
+    // Poll until the session reaches a terminal state, or we hit the timeout.
     let state = "running";
+    const startedAt = Date.now();
     while (state === "running") {
+      if (Date.now() - startedAt > config.sessionTimeoutMs) {
+        state = "timeout";
+        break;
+      }
       await sleep(config.pollIntervalMs);
       state = await adapter.getStatus(sessionId);
     }

--- a/request-orchestrator/src/orchestrator.js
+++ b/request-orchestrator/src/orchestrator.js
@@ -1,0 +1,63 @@
+// The processing loop: claim the next approved request, create ONE Claude session,
+// wait for it to finish, record the result, then move on. Concurrency is capped at
+// config.maxConcurrency (default 1) so sessions never overlap.
+import { config } from "./config.js";
+import { claimNext, markSession, markDone, markFailed } from "./queue.js";
+import { buildPrompt } from "./prompt.js";
+
+async function loadAdapter() {
+  const name = config.adapter === "localCli" ? "localCli" : "ccrApi";
+  return import(`./adapters/${name}.js`);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let running = false;
+
+export async function tick() {
+  if (running) return; // guard against re-entrancy while a session is in flight
+  const req = claimNext(config.maxConcurrency);
+  if (!req) return;
+
+  running = true;
+  const adapter = await loadAdapter();
+  try {
+    const { sessionId, sessionUrl } = await adapter.createSession(buildPrompt(req), req);
+    markSession(req.id, { sessionId, sessionUrl });
+    console.log(`[orchestrator] started ${req.id} -> session ${sessionId}`);
+
+    // Poll until the session reaches a terminal state.
+    let state = "running";
+    while (state === "running") {
+      await sleep(config.pollIntervalMs);
+      state = await adapter.getStatus(sessionId);
+    }
+
+    if (state === "done") {
+      markDone(req.id, `session ${sessionId} completed`);
+      console.log(`[orchestrator] done ${req.id}`);
+    } else {
+      markFailed(req.id, `session ${sessionId} ended as ${state}`);
+      console.log(`[orchestrator] failed ${req.id}: ${state}`);
+    }
+  } catch (err) {
+    markFailed(req.id, err);
+    console.error(`[orchestrator] error on ${req.id}:`, err.message);
+  } finally {
+    running = false;
+  }
+}
+
+// Start the loop. Returns a stop() function.
+export function start() {
+  let stopped = false;
+  (async function loop() {
+    while (!stopped) {
+      await tick();
+      await sleep(2000); // small idle poll between claims
+    }
+  })();
+  return () => {
+    stopped = true;
+  };
+}

--- a/request-orchestrator/src/prompt.js
+++ b/request-orchestrator/src/prompt.js
@@ -1,0 +1,24 @@
+// Turn an approved request into a Claude session prompt.
+export function buildPrompt(req) {
+  const lines = [];
+  lines.push(`בקשה שאושרה על ידי אייל במערכת הבקשות. בצע אותה מקצה לקצה.`);
+  lines.push("");
+  lines.push(`# ${req.title || "(ללא כותרת)"}`);
+  if (req.system) lines.push(`מערכת: ${req.system}`);
+  if (req.requester) lines.push(`מבקש: ${req.requester}`);
+  lines.push("");
+  lines.push("## מה לבצע");
+  lines.push(req.body || "(לא צורף פירוט — פנה לאייל אם לא ברור)");
+  if (req.acceptance) {
+    lines.push("");
+    lines.push("## קריטריון סיום (בוצע כאשר)");
+    lines.push(req.acceptance);
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push(
+    "כללי-חובה: לפני עריכת קובץ/מערכת חיה ודא שאין סשן אחר על אותו קובץ; גבה לפני שינוי; " +
+      "אל תעלה נתוני לקוחות לשירות חיצוני; בסיום דווח מה בוצע. אם הבקשה לא ברורה — עצור ושאל, אל תנחש."
+  );
+  return lines.join("\n");
+}

--- a/request-orchestrator/src/queue.js
+++ b/request-orchestrator/src/queue.js
@@ -1,10 +1,10 @@
 // File-backed FIFO queue of approved requests. Persisted so a crash never loses
 // or double-runs a request. Single-writer (the orchestrator process) + atomic rename.
 import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from "node:fs";
-import { join } from "node:path";
-import { DATA_DIR } from "./config.js";
+import { dirname } from "node:path";
+import { config } from "./config.js";
 
-const QUEUE_FILE = join(DATA_DIR, "approved-queue.json");
+const QUEUE_FILE = config.queueFile;
 
 // status: "pending" -> "running" -> "done" | "failed"
 function load() {
@@ -17,7 +17,7 @@ function load() {
 }
 
 function save(items) {
-  mkdirSync(DATA_DIR, { recursive: true });
+  mkdirSync(dirname(QUEUE_FILE), { recursive: true });
   const tmp = QUEUE_FILE + ".tmp";
   writeFileSync(tmp, JSON.stringify(items, null, 2));
   renameSync(tmp, QUEUE_FILE); // atomic on same filesystem

--- a/request-orchestrator/src/queue.js
+++ b/request-orchestrator/src/queue.js
@@ -1,0 +1,80 @@
+// File-backed FIFO queue of approved requests. Persisted so a crash never loses
+// or double-runs a request. Single-writer (the orchestrator process) + atomic rename.
+import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { DATA_DIR } from "./config.js";
+
+const QUEUE_FILE = join(DATA_DIR, "approved-queue.json");
+
+// status: "pending" -> "running" -> "done" | "failed"
+function load() {
+  if (!existsSync(QUEUE_FILE)) return [];
+  try {
+    return JSON.parse(readFileSync(QUEUE_FILE, "utf8"));
+  } catch {
+    return [];
+  }
+}
+
+function save(items) {
+  mkdirSync(DATA_DIR, { recursive: true });
+  const tmp = QUEUE_FILE + ".tmp";
+  writeFileSync(tmp, JSON.stringify(items, null, 2));
+  renameSync(tmp, QUEUE_FILE); // atomic on same filesystem
+}
+
+export function enqueue(request) {
+  const items = load();
+  if (items.some((i) => i.id === request.id && i.status !== "failed")) {
+    return { added: false, reason: "duplicate-id" }; // idempotent: never enqueue same live request twice
+  }
+  items.push({
+    ...request,
+    status: "pending",
+    enqueuedAt: new Date().toISOString(),
+    claimedAt: null,
+    finishedAt: null,
+    sessionId: null,
+    sessionUrl: null,
+    result: null,
+    error: null,
+  });
+  save(items);
+  return { added: true };
+}
+
+// Claim the oldest pending item (FIFO). Returns null if none / something already running.
+export function claimNext(maxConcurrency) {
+  const items = load();
+  const running = items.filter((i) => i.status === "running").length;
+  if (running >= maxConcurrency) return null; // enforce no-overlap
+  const next = items.find((i) => i.status === "pending");
+  if (!next) return null;
+  next.status = "running";
+  next.claimedAt = new Date().toISOString();
+  save(items);
+  return next;
+}
+
+export function markSession(id, { sessionId, sessionUrl }) {
+  patch(id, { sessionId, sessionUrl });
+}
+
+export function markDone(id, result) {
+  patch(id, { status: "done", result: result ?? null, finishedAt: new Date().toISOString() });
+}
+
+export function markFailed(id, error) {
+  patch(id, { status: "failed", error: String(error), finishedAt: new Date().toISOString() });
+}
+
+function patch(id, fields) {
+  const items = load();
+  const it = items.find((i) => i.id === id);
+  if (it) Object.assign(it, fields);
+  save(items);
+}
+
+export function all() {
+  return load();
+}

--- a/request-orchestrator/src/server.js
+++ b/request-orchestrator/src/server.js
@@ -1,0 +1,59 @@
+// Tiny HTTP API the /requests app talks to. No framework — Node's http only.
+//   POST /approve  { id, title, body, system?, requester?, acceptance? }
+//   GET  /status   -> current queue with per-request state
+import { createServer } from "node:http";
+import { config } from "./config.js";
+import { enqueue, all } from "./queue.js";
+
+function send(res, code, obj) {
+  const body = JSON.stringify(obj);
+  res.writeHead(code, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(body);
+}
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (c) => (data += c));
+    req.on("end", () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+export function startServer() {
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.method === "POST" && req.url === "/approve") {
+        const body = await readJson(req);
+        if (!body.id || !body.title) {
+          return send(res, 400, { ok: false, error: "id and title are required" });
+        }
+        const result = enqueue({
+          id: String(body.id),
+          title: String(body.title),
+          body: body.body ? String(body.body) : "",
+          system: body.system ? String(body.system) : null,
+          requester: body.requester ? String(body.requester) : null,
+          acceptance: body.acceptance ? String(body.acceptance) : null,
+        });
+        return send(res, result.added ? 202 : 200, { ok: true, ...result });
+      }
+      if (req.method === "GET" && req.url === "/status") {
+        return send(res, 200, { ok: true, requests: all() });
+      }
+      send(res, 404, { ok: false, error: "not found" });
+    } catch (err) {
+      send(res, 500, { ok: false, error: String(err) });
+    }
+  });
+  server.listen(config.port, () => {
+    console.log(`[server] listening on http://localhost:${config.port}  (adapter=${config.adapter})`);
+  });
+  return server;
+}

--- a/request-orchestrator/src/server.js
+++ b/request-orchestrator/src/server.js
@@ -2,8 +2,19 @@
 //   POST /approve  { id, title, body, system?, requester?, acceptance? }
 //   GET  /status   -> current queue with per-request state
 import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { config } from "./config.js";
 import { enqueue, all } from "./queue.js";
+
+const PUBLIC_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "public");
+
+function summarize(items) {
+  const by = { pending: 0, running: 0, done: 0, failed: 0 };
+  for (const i of items) if (by[i.status] !== undefined) by[i.status]++;
+  return by;
+}
 
 function send(res, code, obj) {
   const body = JSON.stringify(obj);
@@ -45,7 +56,17 @@ export function startServer() {
         return send(res, result.added ? 202 : 200, { ok: true, ...result });
       }
       if (req.method === "GET" && req.url === "/status") {
-        return send(res, 200, { ok: true, requests: all() });
+        const items = all();
+        return send(res, 200, { ok: true, summary: summarize(items), requests: items });
+      }
+      if (req.method === "GET" && (req.url === "/" || req.url === "/dashboard")) {
+        try {
+          const html = readFileSync(join(PUBLIC_DIR, "dashboard.html"));
+          res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+          return res.end(html);
+        } catch {
+          return send(res, 404, { ok: false, error: "dashboard not found" });
+        }
       }
       send(res, 404, { ok: false, error: "not found" });
     } catch (err) {

--- a/request-orchestrator/test/pipeline.test.js
+++ b/request-orchestrator/test/pipeline.test.js
@@ -1,0 +1,38 @@
+// End-to-end: approve -> queue -> orchestrator tick -> mock session -> done.
+// Uses the mock adapter and a tiny poll interval so it runs fast.
+process.env.ADAPTER = "mock";
+process.env.POLL_INTERVAL_MS = "5";
+process.env.SESSION_TIMEOUT_MS = "10000";
+process.env.QUEUE_FILE = "data/test-pipeline-queue.json";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+// Dynamic import so the env vars above are set BEFORE config.js reads them
+// (static imports are hoisted and would run first).
+const { DATA_DIR } = await import("../src/config.js");
+rmSync(join(DATA_DIR, "approved-queue.json"), { force: true });
+mkdirSync(DATA_DIR, { recursive: true });
+
+const { enqueue, all } = await import("../src/queue.js");
+const { tick } = await import("../src/orchestrator.js");
+
+test("approved request runs to done via the mock adapter", async () => {
+  enqueue({ id: "P1", title: "בדיקת פייפליין", body: "do it", requester: "אייל" });
+  await tick(); // claims P1, runs the mock session to completion
+  const it = all().find((i) => i.id === "P1");
+  assert.equal(it.status, "done");
+  assert.ok(it.sessionId && it.sessionId.startsWith("mock-"));
+  assert.ok(it.finishedAt);
+});
+
+test("a second request waits until the first is finished (serialized)", async () => {
+  enqueue({ id: "P2", title: "שני" });
+  enqueue({ id: "P3", title: "שלישי" });
+  await tick(); // P2
+  await tick(); // P3
+  const done = all().filter((i) => ["P2", "P3"].includes(i.id) && i.status === "done");
+  assert.equal(done.length, 2);
+});

--- a/request-orchestrator/test/queue.test.js
+++ b/request-orchestrator/test/queue.test.js
@@ -1,0 +1,37 @@
+// Verifies the core guarantee: with maxConcurrency=1, only one request is ever
+// "running" at a time, claims are FIFO, and enqueue is idempotent per id.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { DATA_DIR } from "../src/config.js";
+
+// clean slate
+rmSync(join(DATA_DIR, "approved-queue.json"), { force: true });
+mkdirSync(DATA_DIR, { recursive: true });
+
+const { enqueue, claimNext, markDone, all } = await import("../src/queue.js");
+
+test("enqueue is idempotent per id", () => {
+  enqueue({ id: "A", title: "first" });
+  const r = enqueue({ id: "A", title: "dup" });
+  assert.equal(r.added, false);
+  assert.equal(all().filter((i) => i.id === "A").length, 1);
+});
+
+test("claimNext enforces no-overlap and FIFO", () => {
+  enqueue({ id: "B", title: "second" });
+  const first = claimNext(1);
+  assert.equal(first.id, "A"); // FIFO: A before B
+  // A is now running -> nothing else can be claimed at concurrency 1
+  assert.equal(claimNext(1), null);
+  // finish A, then B becomes claimable
+  markDone("A", "ok");
+  const second = claimNext(1);
+  assert.equal(second.id, "B");
+});
+
+test("running count never exceeds concurrency", () => {
+  const running = all().filter((i) => i.status === "running").length;
+  assert.ok(running <= 1);
+});

--- a/request-orchestrator/test/queue.test.js
+++ b/request-orchestrator/test/queue.test.js
@@ -1,14 +1,16 @@
 // Verifies the core guarantee: with maxConcurrency=1, only one request is ever
 // "running" at a time, claims are FIFO, and enqueue is idempotent per id.
+process.env.QUEUE_FILE = "data/test-queue.json";
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { rmSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { DATA_DIR } from "../src/config.js";
+import { dirname } from "node:path";
 
-// clean slate
-rmSync(join(DATA_DIR, "approved-queue.json"), { force: true });
-mkdirSync(DATA_DIR, { recursive: true });
+// Dynamic import so QUEUE_FILE above is read by config before the queue loads.
+const { config, DATA_DIR } = await import("../src/config.js");
+rmSync(config.queueFile, { force: true });
+mkdirSync(dirname(config.queueFile), { recursive: true });
 
 const { enqueue, claimNext, markDone, all } = await import("../src/queue.js");
 


### PR DESCRIPTION
## מה זה

מנוע שמחבר את **מערכת הבקשות** (`/requests` ב-OfficeChatServer, פורט 3000) ל-**Claude Code Remote**:
כל בקשה שאייל מאשר יוצרת אוטומטית סשן Claude שמבצע אותה — **בטור, בלי שסשן אחד יתלבש על אחר**.

## איך זה עובד

```
/requests →(אישור, POST /approve)→ approved-queue.json → orchestrator (concurrency=1) → סשן Claude → GET /status → לוח בעברית
```

- תור FIFO נשמר לדיסק, מצבים pending/running/done/failed — crash-safe ואידמפוטנטי לפי id.
- `MAX_CONCURRENCY=1` + קובץ נעילה → אף פעם לא שני סשנים במקביל.
- `SESSION_TIMEOUT_MS` — סשן תקוע נכשל אוטומטית כדי שהתור לא ייתקע.
- שלושה adapters: `ccrApi` (ענן) · `localCli` (הרצה מקומית על מכונת המשרד) · `mock` (בדיקות/הדגמה).
- API קטן: `POST /approve`, `GET /status`; **לוח בקשות/סשנים בעברית** מוגש מ-`GET /` ומתעדכן לבד.

## נוסף בסבב האחרון (11.07 לילה)

- 🖥️ **לוח בעברית** (`public/dashboard.html`) — RTL, אריחי סיכום + טבלת בקשות, מתעדכן כל 5 שניות.
- 🧪 **mock adapter** — הרצה מקצה-לקצה בלי CCR ובלי CLI (`ADAPTER=mock`).
- ⏱️ **timeout לסשן** + summary counts ב-`/status`.
- 📄 **HANDOFF.md** — מה מוכן, מה חסר, ואיך מריצים כבר היום.

## מה עוד צריך כדי לעלות לאוויר

1. פרטי ה-API של Claude Code Remote (כתובת + טוקן + env id) ל-.env — יש TODO אחד ב-`ccrApi.js`.
2. הוספת ה-`fetch("/approve")` לכפתור "אשר" ב-`/requests` (דוגמת קוד ב-README).
3. ייצוא הבקשות הקיימות (JSON/CSV) — הסשן בענן לא מגיע ל-localhost:3000.

## בדיקות

- `node --test` — **5/5 עוברים** (אי-התנגשות, FIFO, אידמפוטנטיות, פייפליין מלא עם mock).
- Smoke חי: `ADAPTER=mock` → אישור → תור → סשן → done, והלוח הציג את המצב.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwYw6sHYNWJKBhZGv5B5fB